### PR TITLE
venv support, custom color support, and minor tweaks

### DIFF
--- a/parrot.zsh-theme
+++ b/parrot.zsh-theme
@@ -1,7 +1,25 @@
-PROMPT=$'%{$fg[red]%}┌[%{$fg_bold[brown]%}%n%{$reset_color%}%{$fg[yellow]%}@%{$fg_bold[blue]%}%m%{$reset_color%}%{$fg[red]%}][%{$fg[green]%}%~%{$reset_color%}%{$fg[red]%}]> %{$(git_prompt_info)%}%(?,,%{$fg[red]%}[%{$fg_bold[white]%}%?%{$reset_color%}%{$fg[red]%}])
-%{$fg[red]%}└──╼%{$fg_bold[yellow]%}$%{$reset_color%} '
-PS2=$' %{$fg[green]%}|>%{$reset_color%} '
+PARROT_LINE_COLOR=red
+PARROT_ERR_COLOR=red
+PARROT_USER_COLOR=red
+PARROT_AT_COLOR=yellow
+PARROT_HOST_COLOR=cyan
+PARROT_DIR_COLOR=green
+PARROT_PROMPT_COLOR=yellow
+PARROT_GIT_BRANCH_COLOR=white
+PARROT_GIT_STATUS_COLOR=red
+PARROT_VENV_COLOR=white
+PARROT_PS2_PROMPT_COLOR=green
 
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[red]%}[%{$fg_bold[white]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}%{$fg[red]%}] "
-ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg[red]%}⚡%{$reset_color%}"
+# override default virtualenv indicator in prompt
+VIRTUAL_ENV_DISABLE_PROMPT=1
+venv_info() {
+    [ $VIRTUAL_ENV ] && echo "(%{$fg[$PARROT_VENV_COLOR]%}$(basename $VIRTUAL_ENV)%{$fg[$PARROT_LINE_COLOR]%})"
+}
+
+PROMPT=$'%{$fg[$PARROT_LINE_COLOR]%}┌─%(?,,%{$fg[$PARROT_LINE_COLOR]%}[%{$fg_bold[$PARROT_ERR_COLOR]%}✗%{$reset_color%}%{$fg[$PARROT_LINE_COLOR]%}]─)$(venv_info)[%{$fg_bold[$PARROT_USER_COLOR]%}%n%{$reset_color%}%{$fg_bold[$PARROT_AT_COLOR]%}@%{$fg_bold[$PARROT_HOST_COLOR]%}%m%{$reset_color%}%{$fg[$PARROT_LINE_COLOR]%}]─[%{$fg[$PARROT_DIR_COLOR]%}%~%{$reset_color%}%{$fg[$PARROT_LINE_COLOR]%}]%{$(git_prompt_info)%}
+%{$fg[$PARROT_LINE_COLOR]%}└──╼ %{$fg_bold[$PARROT_PROMPT_COLOR]%}%(!.#.$)%{$reset_color%} '
+PS2=$' %{$fg[$PARROT_PS2_PROMPT_COLOR]%}|>%{$reset_color%} '
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[$PARROT_LINE_COLOR]%}(%{$fg_bold[$PARROT_GIT_BRANCH_COLOR]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}%{$fg[$PARROT_LINE_COLOR]%}) "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg[$PARROT_GIT_STATUS_COLOR]%}⚡%{$reset_color%}"


### PR DESCRIPTION
# Overview
Made some minor tweaks and added color variables to make life easy in case someone wants to customize. Just thought I'd share in case you think others would like any of these changes. Thanks for creating this!

- added support for python venv indicator
- specified colors in variables (to make it easier to change colors if desired)
- traded the square brackets around the git branch for parenthesis (just looks more balanced with the venv, IMO).

### Before
When a virtual environment is activated, the prompt looks broken.

<img width="804" alt="Screen Shot 2021-07-19 at 2 05 02 PM" src="https://user-images.githubusercontent.com/4702431/126227949-0bfbdb82-de87-4297-9ab5-b655c3d88d5b.png">

### After
Virtual environment indicator integrated into prompt (along with a few other minor tweaks)

<img width="804" alt="Screen Shot 2021-07-19 at 2 07 20 PM" src="https://user-images.githubusercontent.com/4702431/126227967-1cfcef4c-bdf0-4d77-8b99-a440d550b6b2.png">

